### PR TITLE
Remove legacy storefront CSS

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
-import "./storefront-1.css";
-import "./storefront-2.css";
-import "./storefront-3.css";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://silentscript.vercel.app"),


### PR DESCRIPTION
Removes the three old global storefront stylesheet imports so the new production design is rendered without legacy `.ss-*` selector conflicts. Metadata and backend routes remain unchanged.